### PR TITLE
Refactor parser internals and add tests

### DIFF
--- a/Parsec.java
+++ b/Parsec.java
@@ -7,11 +7,20 @@ class Parsec<T> {
      * @param <T> the underlying type of the result
      */
     static class ParserResult<T>{
-        Optional<T> result;
-        String parseNext;
+        private final Optional<T> result;
+        private final String parseNext;
+
         ParserResult(Optional<T> res, String next){
             result = res;
             parseNext=  next;
+        }
+
+        Optional<T> getResult() {
+            return result;
+        }
+
+        String getParseNext() {
+            return parseNext;
         }
     }
 
@@ -48,11 +57,11 @@ class Parsec<T> {
     <U> Parsec<U> bind(Function<T, Parsec<U>> binder) {
         return new Parsec<U>(s -> {
             ParserResult<T> res = runParser(s);
-            if (res.result.isEmpty()) {
-                return new ParserResult(Optional.empty(), res.parseNext);
+            if (res.getResult().isEmpty()) {
+                return new ParserResult<>(Optional.empty(), res.getParseNext());
             }
 
-            return binder.apply((res.result.get())).runParser(res.parseNext);
+            return binder.apply(res.getResult().get()).runParser(res.getParseNext());
         });
     }
 }

--- a/ParsecTest.java
+++ b/ParsecTest.java
@@ -1,0 +1,39 @@
+import java.util.List;
+
+public class ParsecTest {
+    public static void main(String[] args) {
+        testStudentFromJson();
+        testGradeParserLongList();
+        System.out.println("All tests passed");
+    }
+
+    static void testStudentFromJson() {
+        String json = "{\"name\":guy,\"id\":12345,\"grades\":[100,90,80]}";
+        var res = Main.studentFromJson().runParser(json);
+        assert res.getResult().isPresent();
+        Main.Student s = res.getResult().get();
+        assert s.toString().equals("name: guy id: 12345 grades: [100,90,80]");
+    }
+
+    static void testGradeParserLongList() {
+        StringBuilder gradesBuilder = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            if (i > 0) gradesBuilder.append(",");
+            gradesBuilder.append("1");
+        }
+        gradesBuilder.append("]");
+        Parsec<List<Integer>> parser = Main.gradeParser(
+                ParsecUtils.some(ParsecUtils.digit()).bind(digits -> {
+                    int num = 0;
+                    for (char d : digits) {
+                        num = num * 10 + (d - '0');
+                    }
+                    return ParsecUtils.unit(num);
+                }),
+                ParsecUtils.charParser(','),
+                ParsecUtils.charParser(']'));
+        var res = parser.runParser(gradesBuilder.toString());
+        assert res.getResult().isPresent();
+        assert res.getResult().get().size() == 1000;
+    }
+}

--- a/ParsecUtils.java
+++ b/ParsecUtils.java
@@ -35,10 +35,10 @@ public class ParsecUtils {
      * @param <T>
      * @return A parser which encapsulates the logic of tyring the first and defaulting to the second
      */
-    static <T> Parsec<T> option(Parsec p1, Parsec p2){
-        return new Parsec<>((Function<String, Parsec.ParserResult<T>>) s -> {
+    static <T> Parsec<T> option(Parsec<T> p1, Parsec<T> p2){
+        return new Parsec<>(s -> {
             var result = p1.runParser(s);
-            if(result.result.isEmpty()){
+            if(result.getResult().isEmpty()){
                 return p2.runParser(s);
             }
 


### PR DESCRIPTION
## Summary
- Make ParserResult immutable with getters
- Generic option combinator to avoid raw types
- Simplify student parsing and replace recursive grade parser with iterative version
- Add basic parsing tests

## Testing
- `javac -Xlint:unchecked *.java`
- `java -ea ParsecTest`


------
https://chatgpt.com/codex/tasks/task_e_68bd16f825388328abe9813b15cccf1c